### PR TITLE
Feat/did contenteditable

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,0 +1,20 @@
+# source: https://docs.github.com/en/actions/guides/publishing-nodejs-packages
+name: Publish Package to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Setup .npmrc file to publish to npm Packages
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm install
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@i4k/4000-network",
+  "name": "@internet4000/4000-network",
   "version": "0.0.1",
-  "description": "subdomains site for *.4000.network",
+  "description": "Subdomains profile site for *.4000.network",
   "type": "module",
   "main": "src/index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   "bugs": {
     "url": "https://github.com/internet4000/4000.network/issues"
   },
-  "homepage": "https://github.com/internet4000/4000.network#readme",
+  "homepage": "https://github.com/internet4000/4000.network",
   "devDependencies": {
     "vite": "^4.3.9"
   },

--- a/src/components/network-4000.js
+++ b/src/components/network-4000.js
@@ -1,4 +1,4 @@
-import { readSubdomain } from "../libs/sdk.js";
+import { readDocument } from "../libs/sdk.js";
 
 export default class Network4000 extends HTMLElement {
 	static get observedAttributes() {
@@ -6,6 +6,7 @@ export default class Network4000 extends HTMLElement {
 			/* props */
 			"hostname",
 			"subdomain",
+			"did-method",
 			"flag-development",
 			/* state */
 			"pathname",
@@ -42,6 +43,9 @@ export default class Network4000 extends HTMLElement {
 	get origin() {
 		return new URL(`https://${this.hostname || window.location.origin}`);
 	}
+	get didMethod() {
+		return this.getAttribute("did-method") || "github";
+	}
 	get allowedOrigins() {
 		return [this.origin];
 	}
@@ -74,7 +78,10 @@ export default class Network4000 extends HTMLElement {
 		}
 		/* if we're on a subdomain page, try loading it's config */
 		if (this.subdomain) {
-			const { data, error } = await readSubdomain(this.subdomain);
+			const { data, error } = await readDocument(
+				this.subdomain,
+				this.didMethod
+			);
 			/* if there are no config for a subdomain, load 404 */
 			if (data) {
 				/* otherwise, let's load the config and render it */
@@ -134,6 +141,7 @@ export default class Network4000 extends HTMLElement {
 	renderSubdomain() {
 		this.innerHTML = "";
 		const $profile = document.createElement("network-profile");
+		$profile.setAttribute("did-method", this.didMethod);
 		if (this.subdomainConfig) {
 			$profile.setAttribute("config", JSON.stringify(this.subdomainConfig));
 		}
@@ -149,6 +157,7 @@ export default class Network4000 extends HTMLElement {
 	}
 	renderHome() {
 		const $search = document.createElement("network-search");
+		$search.setAttribute("did-method", this.didMethod);
 		$search.addEventListener("search", () => {});
 		$search.addEventListener("match", this.onSearchMatch.bind(this));
 		this.append($search);

--- a/src/components/network-4000.js
+++ b/src/components/network-4000.js
@@ -72,6 +72,11 @@ export default class Network4000 extends HTMLElement {
 		window.location = url;
 	}
 
+	onContentInput(event) {
+		console.log("on content input", event);
+		// parse document (y3js?)
+	}
+
 	async connectedCallback() {
 		if (this.isEditing) {
 			this.setAttribute("is-editing", this.isEditing);
@@ -144,6 +149,10 @@ export default class Network4000 extends HTMLElement {
 		$profile.setAttribute("did-method", this.didMethod);
 		if (this.subdomainConfig) {
 			$profile.setAttribute("config", JSON.stringify(this.subdomainConfig));
+		}
+		if (this.searchParams.edit) {
+			$profile.setAttribute("contenteditable", true);
+			$profile.addEventListener("input", this.onContentInput.bind(this));
 		}
 		this.append($profile);
 

--- a/src/components/network-profile-edit.js
+++ b/src/components/network-profile-edit.js
@@ -1,7 +1,7 @@
 import {
 	AUTHORIZED_WIDGETS,
-	getProfileFileEditUrl,
-	getProfileFileUrl,
+	getDocumentEditUrl,
+	getDocumentUrl,
 } from "../libs/sdk.js";
 
 const buildTemplate = ({ jsonValidatorUrl, editUrl, fileUrl }) => {
@@ -20,7 +20,7 @@ const buildTemplate = ({ jsonValidatorUrl, editUrl, fileUrl }) => {
 					<a href="${jsonValidatorUrl}">JSON validator</a>
 				</li>
 			</ul>
-			<ol></ol>
+			<section></section>
 		</details>
 	`;
 };
@@ -31,6 +31,7 @@ export default class NetworkProfileEdit extends HTMLElement {
 			/* props */
 			"config",
 			"subdomain",
+			"did-method",
 		];
 	}
 
@@ -38,7 +39,9 @@ export default class NetworkProfileEdit extends HTMLElement {
 	get subdomain() {
 		return this.getAttribute("subdomain");
 	}
-
+	get didMethod() {
+		return this.getAttribute("did-method") || "github";
+	}
 	/* get the config for a subdomain profile */
 	get config() {
 		let data;
@@ -47,7 +50,6 @@ export default class NetworkProfileEdit extends HTMLElement {
 		} catch (e) {}
 		return data;
 	}
-
 	get name() {
 		if (this.config && this.config.name) {
 			return this.config.name;
@@ -75,21 +77,20 @@ export default class NetworkProfileEdit extends HTMLElement {
 	connectedCallback() {
 		this.innerHTML = buildTemplate({
 			jsonValidatorUrl: `https://duckduckgo.com/?q=json+validator`,
-			editUrl: getProfileFileEditUrl(this.subdomain),
-			fileUrl: getProfileFileUrl(this.subdomain),
+			editUrl: getDocumentEditUrl(this.subdomain, this.didMethod),
+			fileUrl: getDocumentUrl(this.subdomain, this.didMethod),
 		});
 		this.$widgets = this.querySelector("ol");
 	}
 
 	render() {
 		if (this.widgets) {
-			this.renderWidgets();
+			this.renderWidgetsManager();
 		}
 	}
-	renderWidgets() {
-		this.widgets.forEach((widget) => {
-			console.log(widget);
-		});
+	renderWidgetsManager() {
+		const $widgetManager = document.createElement("widget-manager");
+		this.append($widgetManager);
 	}
 }
 

--- a/src/components/network-profile.js
+++ b/src/components/network-profile.js
@@ -5,6 +5,7 @@ export default class NetworkProfile extends HTMLElement {
 		return [
 			/* props */
 			"config",
+			"did-method",
 		];
 	}
 
@@ -15,6 +16,9 @@ export default class NetworkProfile extends HTMLElement {
 			data = JSON.parse(this.getAttribute("config"));
 		} catch (e) {}
 		return data;
+	}
+	get didMethod() {
+		return this.getAttribute("did-method") || "github";
 	}
 
 	get name() {

--- a/src/components/network-search.js
+++ b/src/components/network-search.js
@@ -1,15 +1,16 @@
 import { searchGithub } from "../libs/sdk.js";
+import { homepage } from "../../package.json";
 
 const template = `
-<form>
-	<fieldset>
-		<label>
-			Find 4000 profile
-			<input type="text" list="search-results" placeholder="search profiles"/>
-		</label>
-		<datalist id="search-results"></datalist>
-	</fieldset>
-</form>
+	<form>
+		<fieldset>
+			<label>
+				Find <a href="${homepage}">4000</a> profile
+				<input type="text" list="search-results" placeholder="username"/>
+			</label>
+			<datalist id="search-results"></datalist>
+		</fieldset>
+	</form>
 `;
 
 export default class NetworkSearch extends HTMLElement {

--- a/src/components/network-search.js
+++ b/src/components/network-search.js
@@ -1,4 +1,4 @@
-import { searchGithub } from "../libs/sdk.js";
+import { searchNetwork } from "../libs/sdk.js";
 import { homepage } from "../../package.json";
 
 const template = `
@@ -14,6 +14,12 @@ const template = `
 `;
 
 export default class NetworkSearch extends HTMLElement {
+	static get observedAttributes() {
+		return ["did-method"];
+	}
+	get didMethod() {
+		return this.getAttribute("did-method") || "github";
+	}
 	constructor() {
 		super();
 	}
@@ -59,7 +65,7 @@ export default class NetworkSearch extends HTMLElement {
 	}
 
 	async search(value = "") {
-		const { data, error } = await searchGithub(value);
+		const { data, error } = await searchNetwork(value, this.didMethod);
 		this.dispatchEvent(
 			new CustomEvent("search", {
 				detail: { data, error },

--- a/src/libs/did-github.js
+++ b/src/libs/did-github.js
@@ -1,0 +1,54 @@
+export default class DIDGithub {
+	async fetchData(url) {
+		let data, error;
+		try {
+			const response = await fetch(url);
+			if (response.ok) {
+				try {
+					data = await response.json();
+				} catch (e) {
+					error = e;
+				}
+			} else {
+				error = response;
+			}
+		} catch (e) {
+			error = e;
+		}
+		return { data, error };
+	}
+
+	async readDocument(githubUsername) {
+		console.log("read gh");
+		const url = this.getDocumentRawUrl(githubUsername);
+		return this.fetchData(url);
+	}
+
+	async search(query) {
+		const url = this.getSearchUrl(query);
+		let { data, error } = await this.fetchData(url);
+
+		if (!error) {
+			data.items = data.items.map((item) => ({
+				subdomain: item.owner.login,
+				stargazers_count: item.stargazers_count,
+				topics: item.topics,
+			}));
+		}
+		return { data, error };
+	}
+
+	/* docs: https://docs.github.com/en/search-github/searching-on-github/searching-in-forks */
+	getSearchUrl(query) {
+		return `https://api.github.com/search/repositories?q=fork:true+topic:4000-network+topic:profile-json+${query}`;
+	}
+	getDocumentRawUrl(actor) {
+		return `https://raw.githubusercontent.com/${actor}/.4000.network/main/.profile.json`;
+	}
+	getDocumentUrl(actor) {
+		return `https://github.com/${actor}/.4000.network/blob/main/.profile.json`;
+	}
+	getDocumentEditUrl(actor) {
+		return `https://github.com/${actor}/.4000.network/edit/main/.profile.json`;
+	}
+}

--- a/src/libs/sdk.js
+++ b/src/libs/sdk.js
@@ -1,87 +1,62 @@
+import DIDGithub from "./did-github.js";
+
+/* DID methods (github is a DID method;
+	 to get a profile/document as DID ID/subdomain) */
+const DIDS = {
+	github: new DIDGithub(),
+};
+
 const AUTHORIZED_WIDGETS_MAP = {
 	"matrix-room-element": [],
 	p: [],
 };
 const AUTHORIZED_WIDGETS = Object.keys(AUTHORIZED_WIDGETS_MAP);
 
-class GithubFileFetcher {
-	async fetchData(url) {
-		let data, error;
-		try {
-			const response = await fetch(url);
-			if (response.ok) {
-				try {
-					data = await response.json();
-				} catch (e) {
-					error = e;
-				}
-			} else {
-				error = response;
-			}
-		} catch (e) {
-			error = e;
-		}
-		return { data, error };
+const readDocument = (subdomain, didMethod) => {
+	const did = DIDS[didMethod];
+	if (!did) {
+		return;
 	}
-
-	async get4000NetworkGithub(githubUsername) {
-		const url = this.get4000NetworkGithubFileRawUrl(githubUsername);
-		return this.fetchData(url);
+	return did.readDocument(subdomain);
+};
+const searchNetwork = (query, didMethod) => {
+	const did = DIDS[didMethod];
+	if (!did) {
+		return;
 	}
+	return did.search(query);
+};
 
-	async search4000NetworkGithub(query) {
-		const url = this.get4000NetworkGithubSearchUrl(query);
-		let { data, error } = await this.fetchData(url);
-
-		if (!error) {
-			data.items = data.items.map((item) => ({
-				subdomain: item.owner.login,
-				stargazers_count: item.stargazers_count,
-				topics: item.topics,
-			}));
-		}
-		return { data, error };
+const getDocumentUrl = (subdomain, didMethod) => {
+	const did = DIDS[didMethod];
+	if (!did) {
+		return;
 	}
+	return did.getDocumentUrl(subdomain);
+};
 
-	/* docs: https://docs.github.com/en/search-github/searching-on-github/searching-in-forks */
-	get4000NetworkGithubSearchUrl(query) {
-		return `https://api.github.com/search/repositories?q=fork:true+topic:4000-network+topic:profile-json+${query}`;
+const getDocumentEditUrl = (subdomain, didMethod) => {
+	const did = DIDS[didMethod];
+	if (!did) {
+		return;
 	}
+	return did.getDocumentEditUrl(subdomain);
+};
 
-	get4000NetworkGithubFileRawUrl(actor) {
-		return `https://raw.githubusercontent.com/${actor}/.4000.network/main/.profile.json`;
+const getDocumentRawUrl = (subdomain, didMethod) => {
+	const did = DIDS[didMethod];
+	if (!did) {
+		return;
 	}
-
-	get4000NetworkGithubFileUrl(actor) {
-		return `https://github.com/${actor}/.4000.network/blob/main/.profile.json`;
-	}
-
-	get4000NetworkGithubFileEditUrl(actor) {
-		return `https://github.com/${actor}/.4000.network/edit/main/.profile.json`;
-	}
-}
-
-const fetcher = new GithubFileFetcher();
-
-const readSubdomain = (subdomain) => fetcher.get4000NetworkGithub(subdomain);
-
-const searchGithub = (query) => fetcher.search4000NetworkGithub(query);
-
-const getProfileFileUrl = (subdomain) =>
-	fetcher.get4000NetworkGithubFileUrl(subdomain);
-
-const getProfileFileEditUrl = (subdomain) =>
-	fetcher.get4000NetworkGithubFileEditUrl(subdomain);
-
-const getProfileFileRawUrl = (subdomain) =>
-	fetcher.get4000NetworkGithubFileRawUrl(subdomain);
+	return did.getDocumentRawUrl(subdomain);
+};
 
 export {
 	AUTHORIZED_WIDGETS,
 	AUTHORIZED_WIDGETS_MAP,
-	readSubdomain,
-	searchGithub,
-	getProfileFileEditUrl,
-	getProfileFileUrl,
-	getProfileFileRawUrl,
+	readDocument,
+	searchNetwork,
+	getDocumentEditUrl,
+	getDocumentUrl,
+	getDocumentRawUrl,
 };


### PR DESCRIPTION
- add "concept of `DID`"  https://en.wikipedia.org/wiki/Decentralized_identifier to not only be able to handle `github` as identity provider for subdomains
- subsequently refactor naming of sdk methods to `document` naming convention
- add `network-4000[did-method=""]` with default to `github`, since we only have that one currently
- add `network-profile[contenteditable]` and `@input` event listener when query param `?edit` is in the URL; so we can start parsing the content of document, and get HTML elements (and custom elements) back in the DOM tree (and directly see the result of edition -> not done; need custom element widget editor first, to edit attributes; or inline somehow...)
- add links to raw json file and json validator when editing

explore:
- yjs https://github.com/yjs for keeping a document's state (storing to local storage modifications for on page reload retrieval / git sync / rtc peer connection editing